### PR TITLE
fixing package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "files": [
     "src"
   ],
-  "main": "dist/Case.js",
+  "main": "src/Case.js",
   "bugs": {
     "url": "http://github.com/nbubna/Case/issues",
     "email": "nathan@esharesearch.com"


### PR DESCRIPTION
Installing from npm, your dist folder doesn't get included. Aside from the comments, I actually didn't see any change, so it might be worth just installing from the source folder, otherwise there is probably a deeper change involved with including the `dist` folder.

``` shell
$ npm install case
$ ls node_modules/case
README.md    package.json src
$ node
> require('case');
Error: Cannot find module 'case'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at repl:1:2
    at REPLServer.self.eval (repl.js:110:21)
    at Interface.<anonymous> (repl.js:239:12)
    at Interface.EventEmitter.emit (events.js:95:17)
    at Interface._onLine (readline.js:202:10)
    at Interface._line (readline.js:531:8)
```
