### PR TITLE
fix: Publish license information with NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,16 +38,7 @@
     "type": "git",
     "url": "http://github.com/nbubna/Case.git"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://www.opensource.org/licenses/mit-license.php"
-    },
-    {
-      "type": "GPL",
-      "url": "http://www.gnu.org/licenses/gpl.html"
-    }
-  ],
+  "license": "(MIT OR GPL-3.0-or-later)",
   "scripts": {
     "test": "grunt qunit"
   },


### PR DESCRIPTION
Fixes #33 

This commit replaces 'licenses' with
'license' because the former is no
longer valid metadata.

The 'license' is declared using an SPDX
expression and includes the identifiers
for the MIT license and the GPL 3.0 or
later license.

GPL 3.0 or later was selected because
GPL is not a valid identifier and link
in the previous version of code brings
us to the most recent version of the
GPL license.

Sources:
 * https://docs.npmjs.com/files/package.json
 * https://spdx.org/licenses/